### PR TITLE
Refactor for ~250x speedup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 2

--- a/MusicBrainz RYM Link Checker.user.js
+++ b/MusicBrainz RYM Link Checker.user.js
@@ -164,6 +164,7 @@
                     .filter((rel) => rel["target-type"] == entityType)
                     .map((rel) => {
                       return {
+                        success: true,
                         type: entityType,
                         id: rel[entityType].id,
                         url: urlItem.resource,
@@ -172,9 +173,10 @@
               urlsObj[urlItem.resource].callback = null;
             }
           }
-          for(const {callback} of Object.values(urlsObj)){
+          for(const {entityType, callback} of Object.values(urlsObj)){
             if(callback){
-              callback([]);
+              callback([{type: entityType,
+                         success: false,}]);
             }
           }
           if(urlList.length > (offset + 100)){
@@ -183,8 +185,9 @@
         },
         onerror: (response) => {
           console.error(response);
-          for(const {callback} of urls.values()){
-            callback([]);
+          for(const {entityType, callback} of urls.values()){
+            callback([{entityType: entityType,
+                       success: false}]);
           }
         }
       })
@@ -228,7 +231,10 @@
         // TODO seed rymUrl
       } else {
         // For others, link to search
-        const searchType = entityType === "release-group" ? "release_group" : entityType
+        let searchType = entityType;
+        if(searchType == "release-group"){
+          searchType = "release_group";
+        }
         a.href = `https://musicbrainz.org/search?query=${encodeURIComponent(name)}&type=${searchType}&method=indexed`
       }
     }
@@ -262,13 +268,10 @@
   function handleCallback (element, name){
     return (results) => {
       element.removeChild(element.querySelector(".RYM-Link-Checker-Loading-Icon"));
-      if(results.length > 0){
-        for(const result of results){
-          const icon = createIconWithClick(true, createMBzUrl(result.type, result.id), results.id, name, result.url, result.type);
-          element.appendChild(icon);
-        }
-      }else{
-        const icon = createIconWithClick(false, null, null, name, null, null);
+      for(const result of results){
+        const icon = createIconWithClick(result.success,
+				                                 createMBzUrl(result.type, result.id),
+				                                 results.id, name, result.url, result.type);
         element.appendChild(icon);
       }
     }

--- a/MusicBrainz RYM Link Checker.user.js
+++ b/MusicBrainz RYM Link Checker.user.js
@@ -10,15 +10,11 @@
 // @match        https://rateyourmusic.com/release/*
 // @match        https://rateyourmusic.com/artist/*
 // @match        https://rateyourmusic.com/label/*
-// @require      https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
-// @require      https://github.com/murdos/musicbrainz-userscripts/raw/refs/heads/master/lib/logger.js
 // @grant        GM_xmlhttpRequest
 // @connect      musicbrainz.org
 // ==/UserScript==
 
-// prevent JQuery conflicts
-this.$ = this.jQuery = jQuery.noConflict(true)
-;(() => {
+(function () {
   const MB_API = "https://musicbrainz.org/ws/2/"
   const DEBUG = true
   const REQUEST_DELAY = 1100 // 1.1 seconds between requests to respect MB rate limit
@@ -791,4 +787,4 @@ this.$ = this.jQuery = jQuery.noConflict(true)
 
   // Wait for page to load, then run
   setTimeout(run, 1500)
-})()
+})();

--- a/MusicBrainz RYM Link Checker.user.js
+++ b/MusicBrainz RYM Link Checker.user.js
@@ -27,21 +27,17 @@
     if (!url){
       return  null;
     }
-
     try {
       // Remove query parameters and fragments
       let cleanUrl = url.split("?")[0].split("#")[0]
-
       // Ensure https
       cleanUrl = cleanUrl.replace(/^http:/, "https:")
-
-      // Remove trailing slash
-      // cleanUrl = cleanUrl.replace(/\/$/, "")
-
       // Normalize case for path components (but preserve domain case)
       const urlObj = new URL(cleanUrl)
       urlObj.pathname = urlObj.pathname.toLowerCase()
-
+      if(urlObj.pathname.split("/")[1] == "label"){
+        urlObj.pathname = urlObj.pathname.split("/").slice(0,3).join("/") + "/";
+      }
       return urlObj.href
     } catch (e) {
       console.error("Failed to normalize URL:", url, e)

--- a/MusicBrainz RYM Link Checker.user.js
+++ b/MusicBrainz RYM Link Checker.user.js
@@ -16,7 +16,7 @@
 
 (function () {
   const MB_API = "https://musicbrainz.org/ws/2/"
-  const REQUEST_DELAY = 1100 // 1.1 seconds between requests to respect MB rate limit
+  const REQUEST_DELAY = 1000; // 1 second between requests to respect MB rate limit
 
   // Request queue for rate limiting
   const requestQueue = []


### PR DESCRIPTION
The AI-written version of this script was slow for a couple main reasons. First, instead of taking advantage of the API's recently added ability to lookup multiple URLs in a single request ([MBS-13943](https://tickets.metabrainz.org/browse/MBS-13943)), the script made sequential requests for each URL on the page. With more than 50 URLs on some pages this gets slow quick. The other big slowdown came from the script making each request 5 times for the same results. Another benefit of this rewrite is more consistency. Instead of querying the search server for the name of the entity (Freddie Slack), we now lookup the URL directly (https://rateyourmusic.com/artist/freddie_slack/), which should eliminate false negatives for URLs that are connected to MBz but that aren't turned up by our search.