### PR TITLE
feat(quick-recording-match): add dependency note for ISRC companion script

### DIFF
--- a/MusicBrainz Quick Recording Match.user.js
+++ b/MusicBrainz Quick Recording Match.user.js
@@ -2,7 +2,7 @@
 // @name        MusicBrainz Quick Recording Match
 // @namespace   https://github.com/Aerozol/metabrainz-userscripts
 // @description Select the first recording search result for each track, in the release editor Recordings tab.
-// @version     5.20
+// @version     5.21
 // @downloadURL https://raw.githubusercontent.com/Aerozol/metabrainz-userscripts/master/MusicBrainz%20Quick%20Recording%20Match.user.js
 // @updateURL   https://raw.githubusercontent.com/Aerozol/metabrainz-userscripts/master/MusicBrainz%20Quick%20Recording%20Match.user.js
 // @license     MIT

--- a/MusicBrainz Quick Recording Match.user.js
+++ b/MusicBrainz Quick Recording Match.user.js
@@ -361,13 +361,14 @@
         const p1 = document.createElement('p');
         const autoLinkButton = createButton('Auto-link all tracks', startAutoLinking);
         const isrcButton = createButton('Match by ISRC', openIsrcModal);
+        isrcButton.title = 'Requires companion script: MusicBrainz: Search by ISRC in release editor';
         const unlinkButton = createButton('Unlink all tracks', startUnlinking);
         p1.appendChild(autoLinkButton);
         p1.appendChild(isrcButton);
         p1.appendChild(unlinkButton);
         p1.appendChild(createConfidenceDropdown());
         p1.appendChild(createMethodDropdown());
-        p1.appendChild(createStartAtDropdown()); // Add the new dropdown here
+        p1.appendChild(createStartAtDropdown());
         fieldset.appendChild(p1);
 
         return fieldset;
@@ -630,6 +631,14 @@ if (matchingMethod === 'suggested') {
             <p style="margin: 0; font-size: 0.9em; color: #555;">
                 Paste a list of ISRCs below, one per line.<br>
                 Line 1 matches the track selected in the 'Start at' dropdown, Line 2 matches the next, etc.
+            </p>
+            <p style="margin: 0; padding: 8px 10px; font-size: 0.85em; background: #fff8e1; border-left: 3px solid #f9a825; border-radius: 2px; color: #555;">
+                ⚠️ Requires the companion script
+                <a href="https://github.com/chaban-mb/userscripts/raw/main/src/MusicBrainz%20Search%20by%20ISRC%20in%20release%20editor.user.js"
+                   target="_blank" rel="noopener noreferrer" style="color: #1a73e8;">
+                    MusicBrainz: Search by ISRC in release editor
+                </a>
+                to be installed and active.
             </p>
             <textarea id="isrc-paste-area" rows="15" style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; resize: vertical;" placeholder="US-RC1-76-09839\n..."></textarea>
             <div style="display: flex; justify-content: flex-end; gap: 10px;">


### PR DESCRIPTION
_Note: Code and description were written with AI-tools_

### Description
The 'Match by ISRC' feature depends on a companion userscript ([MusicBrainz: Search by ISRC in release editor](https://github.com/chaban-mb/userscripts/raw/main/src/MusicBrainz%20Search%20by%20ISRC%20in%20release%20editor.user.js)) to hook into the recording search and redirect ISRC queries to the MusicBrainz API. Without it, the feature silently does nothing useful. This PR makes that dependency visible to users at both the button and dialog level.

### Key Changes
- Added a `title` tooltip to the 'Match by ISRC' button reading: *'Requires companion script: MusicBrainz: Search by ISRC in release editor'*
- Added a highlighted warning box (amber left-border style) inside the ISRC modal dialog with a direct install link to the companion script

### Verification
- Open the release editor Recordings tab — hover the 'Match by ISRC' button to confirm the tooltip appears
- Click the button to confirm the warning note with the install link is visible in the modal

### Version Bump
- Bumped `MusicBrainz Quick Recording Match` version from `5.20` to `5.21`

### Screenshots
<img width=486 height=65 alt=image src=https://github.com/user-attachments/assets/c95a269d-c461-4e3b-b4a8-3a1dbcbdcf8d />

<img width=441 height=453 alt=image src=https://github.com/user-attachments/assets/ecbe738c-ff84-4098-92dc-f21e7dd0be48 />